### PR TITLE
 feature/TaskList_components PR

### DIFF
--- a/src/components/TaskList.stories.tsx
+++ b/src/components/TaskList.stories.tsx
@@ -1,14 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
 import TaskList from "./TaskList";
 import * as Taskstories from "./Task.stories"
 
-export default {
+const meta = {
   component: TaskList,
   title: 'TaskList',
-  decorators: [(story: () => React.ReactNode) => <div style={{ padding: '3rem' }}>{story()}</div>],
+  decorators: [(story) => <div style={{ padding: '3rem' }}>{story()}</div>],
   tags: ['autodocs'],
-}
+  args: {
+    ...Taskstories.ActionsData,
+  },
+} satisfies Meta<typeof TaskList>
 
-export const Default = {
+export default meta;
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
   args: {
     tasks: [
       { ...Taskstories.Default.args.task, id: '1', title: 'Task 1' },
@@ -21,7 +28,7 @@ export const Default = {
   }
 }
 
-export const WithPinnedTasks = {
+export const WithPinnedTasks: Story = {
   args: {
     tasks: [
       ...Default.args.tasks.slice(0, 5),
@@ -30,14 +37,14 @@ export const WithPinnedTasks = {
   }
 }
 
-export const Loading = {
+export const Loading: Story = {
   args: {
     tasks: [],
     loading: true,
   }
 }
 
-export const Empty = {
+export const Empty: Story = {
   args: {
     ...Loading.args,
     loading: false,

--- a/src/components/TaskList.stories.tsx
+++ b/src/components/TaskList.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import TaskList from "./TaskList";
+import { TaskList } from "./TaskList";
 import * as Taskstories from "./Task.stories"
 
 const meta = {

--- a/src/components/TaskList.stories.tsx
+++ b/src/components/TaskList.stories.tsx
@@ -1,0 +1,45 @@
+import TaskList from "./TaskList";
+import * as Taskstories from "./Task.stories"
+
+export default {
+  component: TaskList,
+  title: 'TaskList',
+  decorators: [(story: () => React.ReactNode) => <div style={{ padding: '3rem' }}>{story()}</div>],
+  tags: ['autodocs'],
+}
+
+export const Default = {
+  args: {
+    tasks: [
+      { ...Taskstories.Default.args.task, id: '1', title: 'Task 1' },
+      { ...Taskstories.Default.args.task, id: '2', title: 'Task 2' },
+      { ...Taskstories.Default.args.task, id: '3', title: 'Task 3' },
+      { ...Taskstories.Default.args.task, id: '4', title: 'Task 4' },
+      { ...Taskstories.Default.args.task, id: '5', title: 'Task 5' },
+      { ...Taskstories.Default.args.task, id: '6', title: 'Task 6' },
+    ]
+  }
+}
+
+export const WithPinnedTasks = {
+  args: {
+    tasks: [
+      ...Default.args.tasks.slice(0, 5),
+      { id: '6', title: 'Task 6(pinned)', state: 'TASK_PINNED' },
+    ]
+  }
+}
+
+export const Loading = {
+  args: {
+    tasks: [],
+    loading: true,
+  }
+}
+
+export const Empty = {
+  args: {
+    ...Loading.args,
+    loading: false,
+  }
+}

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -9,7 +9,7 @@ interface TaskListProps {
   onArchiveTask: (id: string) => void;
 };
 
-const TaskList = ({
+export const TaskList = ({
   loading = false,
   tasks,
   onPinTask,
@@ -20,21 +20,53 @@ const TaskList = ({
     onArchiveTask,
   };
 
+  const LoadingRow = (
+    <div className="loading-item">
+      <span className="glow-checkbox" />
+      <span className="glow-text">
+        <span>Loading</span>
+        <span>cool</span>
+        <span>state</span>
+      </span>
+    </div>
+  )
+
   if (loading) {
-    return <div className="list-item">loading</div>
+    return (
+      <div className="list-item" data-testid="loading" key={"loading"}>
+        {LoadingRow}
+        {LoadingRow}
+        {LoadingRow}
+        {LoadingRow}
+        {LoadingRow}
+        {LoadingRow}
+      </div>
+    )
   }
 
   if (tasks.length === 0) {
-    return <div className="list-item">empty</div>
+    return (
+      <div className="list-items" key={"empty"} data-testid="empty">
+        <div className="wrapper-message">
+          <span className="icon-check" />
+          <p className="title-message">You have no tasks</p>
+          <p className="subtitle-message">Sit back and relax</p>
+        </div>
+      </div>
+    );
   }
 
+  const tasksInOrder = [
+    ...tasks.filter((t) => t.state === "TASK_PINNED"),
+    ...tasks.filter((t) => t.state !== "TASK_PINNED"),
+  ];
   return (
-    <div className="list-item">
-      {tasks.map((task) => (
+    <div className="list-items">
+      {tasksInOrder.map((task) => (
         <Task key={task.id} task={task} {...events} />
       ))}
     </div>
   );
 }
 
-export default TaskList
+

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,0 +1,40 @@
+import type { TaskData } from "../types";
+
+import Task from "./Task";
+
+interface TaskListProps {
+  loading?: boolean
+  tasks: TaskData[]
+  onPinTask: (id: string) => void;
+  onArchiveTask: (id: string) => void;
+};
+
+const TaskList = ({
+  loading = false,
+  tasks,
+  onPinTask,
+  onArchiveTask,
+}: TaskListProps) => {
+  const events = {
+    onPinTask,
+    onArchiveTask,
+  };
+
+  if (loading) {
+    return <div className="list-item">loading</div>
+  }
+
+  if (tasks.length === 0) {
+    return <div className="list-item">empty</div>
+  }
+
+  return (
+    <div className="list-item">
+      {tasks.map((task) => (
+        <Task key={task.id} task={task} {...events} />
+      ))}
+    </div>
+  );
+}
+
+export default TaskList


### PR DESCRIPTION
## 概要

`feature/TaskList_components` ブランチでは、複数のタスクを一覧表示する [`TaskList`](src/components/TaskList.tsx) コンポーネントの実装と、Storybookによる各種状態のストーリー追加を行いました。

## 変更内容

- [`TaskList`](src/components/TaskList.tsx) コンポーネントの新規作成
  - タスク一覧の表示
  - ピン留めタスクを上部に表示
  - ローディング状態・空状態のUI対応
  - 各タスクへのピン・アーカイブ操作の伝播
- [`TaskList.stories.tsx`](src/components/TaskList.stories.tsx) にStorybookストーリーを追加
  - Default（通常表示）
  - WithPinnedTasks（ピン留めタスクあり）
  - Loading（ローディング中）
  - Empty（タスクなし）

## 動作確認

- Storybook上で各状態の表示・操作が正しく動作することを確認済み

## レビュー観点

- タスクの並び順（ピン留め優先）
- propsの型定義や命名
- Storybookストーリーの記述方法

---

関連ファイル:  
- [src/components/TaskList.tsx](src/components/TaskList.tsx)  
- [src/components/TaskList.stories.tsx](src/components/TaskList.stories.tsx)  
-